### PR TITLE
Changes to enable compiling on Windows

### DIFF
--- a/onlineDetection/SpkDonline.cpp
+++ b/onlineDetection/SpkDonline.cpp
@@ -1,7 +1,14 @@
 #include "SpkDonline.h"
 
 namespace SpkDonline {
-Detection::Detection() {}
+Detection::Detection() :
+	// Set default parameters
+	threshold(9), // threshold to detect spikes >11 is likely to be real spikes, but can and should be sorted afterwards
+	AHPthr(0),    // signal should go below that threshold within MaxSl-Slmin frames
+	MaxSl(8),     // dead time in frames after peak, used for further testing
+	MinAvgAmp(5), // minimal avg. amplitude of peak (in units of Qd)
+	MinSl(3)     // length considered for determining avg. spike amplitude
+{}
 
 void Detection::InitDetection(long nFrames, double nSec, int sf, int NCh,
                               long ti, long *Indices) {

--- a/onlineDetection/SpkDonline.h
+++ b/onlineDetection/SpkDonline.h
@@ -7,37 +7,43 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 namespace SpkDonline {
+
 class Detection {
   int NChannels; // number of channels; is set when reading the data
   int *ChInd;    // indices for parallelization
+  
   // Variables for variance and mean
   int *Qd; // noise amplitude
   int *Qm; // median
+  
   // Variables for the spike detection
   int *Sl;      // counter for spike length
   bool *AHP;    // counter for repolarizing current
   int *Amp;     // buffers spike amplitude
   int *SpkArea; // integrates over spike
+  
   // Parameters for variance and mean updates
-  const int Tau_m0 = 4;  // timescale for updating Qm (increment is Qd/Tau_m)
-  const int Qdmin = 200; // set minimum value of Qd
-  // Parameters for spike detection
-  int threshold = 9; // threshold to detect spikes >11 is likely to be real
+  static const int Tau_m0 = 4;  // timescale for updating Qm (increment is Qd/Tau_m)
+  static const int Qdmin = 200; // set minimum value of Qd
+  
+  // Parameters for spike detection (initialized to default values in constructor)
+  int threshold; // threshold to detect spikes >11 is likely to be real
                      // spikes, but can and should be sorted afterwards
-  int AHPthr =
-      0; // signal should go below that threshold within MaxSl-Slmin frames
-  int MaxSl = 8;     // dead time in frames after peak, used for further testing
-  int MinAvgAmp = 5; // minimal avg. amplitude of peak (in units of Qd)
-  int MinSl = 3;     // length considered for determining avg. spike amplitude
+  int AHPthr;    // signal should go below that threshold within MaxSl-Slmin frames
+  int MaxSl;     // dead time in frames after peak, used for further testing
+  int MinAvgAmp; // minimal avg. amplitude of peak (in units of Qd)
+  int MinSl;     // length considered for determining avg. spike amplitude
+  
   // Parameters for reading data
   long tInc; // 100, increment for reading data, has to be changed in main
              // program as well
-  const int Ascale = -64; // factor to multiply to raw traces to increase
+  static const int Ascale = -64; // factor to multiply to raw traces to increase
                           // resolution; definition of ADC counts had been
                           // changed!
-  const int Voffset = 0;  // mean ADC counts, as initial value for Qm
+  static const int Voffset = 0;  // mean ADC counts, as initial value for Qm
+  
   // Parameters for recalibration events and artefact handling
-  const int artT = 10; // to use after artefacts; to update Qm for 10 frames
+  static const int artT = 10; // to use after artefacts; to update Qm for 10 frames
   int *A;              // control parameter for amplifier effects
   // Files to save the spikes etc.
   int Sampling;

--- a/onlineDetection/setup.py
+++ b/onlineDetection/setup.py
@@ -1,5 +1,6 @@
 from Cython.Build import cythonize
 from setuptools import setup, Extension
+import numpy
 
 long_descr = """`See
 <http://github.com/>`_.
@@ -18,5 +19,5 @@ setup(
            language="c++",
            extra_compile_args=['-std=c++11'],
            )),
-    # include_dirs=[numpy.get_include()], requires=['numpy', 'h5py']
+    include_dirs=[numpy.get_include()], requires=['numpy', 'h5py']
 )


### PR DESCRIPTION
Visual Studio doesn't allow default initializing variables which aren't
static-const in the class declaration. Changed "const" to "static const"
and moved the initialization of the other variables to the constructor.
Because those are overwritten anyway, is it really necessary to have
default values?
